### PR TITLE
Ignores dependency scripts on initial prune

### DIFF
--- a/lib/build.sh
+++ b/lib/build.sh
@@ -118,7 +118,7 @@ function install_npm_dependencies {
 
   cd "$package_root"
 
-  npm prune | read_indented
+  npm --ignore-scripts prune | read_indented
   npm install --production --quiet --unsafe-perm 2>&1 | read_indented
   npm rebuild 2>&1 | read_indented
   npm --unsafe-perm prune 2>&1 | read_indented


### PR DESCRIPTION
Fixes binwrap issue for `elmi-to-json`.

To replicate the bug this fixes run `npm prune` in any project without a `elmi-to-json` cached.

The commands which follow it will ultimately run the associated script but not before it exists in memory.